### PR TITLE
Persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ target/
 # --- Editors/IDEs ----------------------------------------------------------
 .idea/
 *.swp
+
+# --- Test files for local development
+output.png
+output.drs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
  "crossbeam-channel",
  "image",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2903,6 +2904,12 @@ checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -4288,6 +4295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4351,6 +4364,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
  "crossbeam-channel",
  "image",
  "rmp-serde",
+ "semver",
  "serde",
  "serde_json",
 ]
@@ -4362,6 +4363,12 @@ name = "self_cell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "send_wrapper"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ dependencies = [
  "bevy",
  "crossbeam-channel",
  "image",
+ "rmp-serde",
  "serde",
  "serde_json",
 ]
@@ -4214,6 +4215,28 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "ron"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 crossbeam-channel = "*"
 image = { version = "*", default-features = false }
 serde = { version = "*", default-features = false }
+serde_json = "1.0.140"
 bevy = { workspace = true, features = [
   "bevy_state",
   "bevy_log",

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -11,7 +11,8 @@ license.workspace = true
 crossbeam-channel = "*"
 image = { version = "*", default-features = false }
 serde = { version = "*", default-features = false }
-serde_json = "1.0.140"
+rmp-serde = { version = "1.3.0" }
+serde_json = { version = "1.0.140", optional = true }
 bevy = { workspace = true, features = [
   "bevy_state",
   "bevy_log",
@@ -26,7 +27,8 @@ bevy = { workspace = true, features = [
 [features]
 dev = [
   "bevy/trace",
-  "bevy/track_location"
+  "bevy/track_location",
+  "dep:serde_json"
 ]
 
 windows = []

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 crossbeam-channel = "*"
 image = { version = "*", default-features = false }
 serde = { version = "*", default-features = false }
-rmp-serde = { version = "1.3.0" }
+rmp-serde = { version = "1.3.0", optional = true }
 serde_json = { version = "1.0.140", optional = true }
 bevy = { workspace = true, features = [
   "bevy_state",
@@ -23,13 +23,18 @@ bevy = { workspace = true, features = [
   "bevy_window",
   "serialize"
 ] }
+semver = "1.0.26"
 
 [features]
+default = ["msgpack"]
+
 dev = [
   "bevy/trace",
-  "bevy/track_location",
-  "dep:serde_json"
+  "bevy/track_location"
 ]
+
+msgpack = ["dep:rmp-serde"]
+json = ["dep:serde_json"]
 
 windows = []
 linux = []

--- a/packages/core/src/components/layer.rs
+++ b/packages/core/src/components/layer.rs
@@ -10,8 +10,4 @@ use bevy::prelude::{Component, Transform, Visibility};
 #[derive(Component, Default)]
 #[component(immutable)]
 #[require(Transform::from_xyz(0.0, 0.0, 0.0), Visibility::default())]
-pub struct Layer {
-    /// The weight determines the order in which layers are rendered.
-    /// A higher weight will render on top, making this an abstraction of the Z index.
-    pub weight: i32,
-}
+pub struct Layer;

--- a/packages/core/src/components/level.rs
+++ b/packages/core/src/components/level.rs
@@ -1,0 +1,11 @@
+use bevy::prelude::{Component, Transform, Visibility};
+
+/// The [Level] component represents a grouping of [crate::components::Layer]s, usually an entire
+/// map, and allows a single [crate::components::Project] to contain several but related maps.
+/// For example, a roadside inn might have a ground floor, upper floor and a basement.
+/// We would represent each of those as a [Level] under the project, each with their own
+/// [Layer]s and entities.
+#[derive(Component, Default)]
+#[component(immutable)]
+#[require(Transform::from_xyz(0.0, 0.0, 0.0), Visibility::default())]
+pub struct Level;

--- a/packages/core/src/components/mod.rs
+++ b/packages/core/src/components/mod.rs
@@ -1,7 +1,9 @@
 mod layer;
 mod level;
 mod project;
+mod texture;
 
 pub use layer::*;
 pub use level::*;
 pub use project::*;
+pub use texture::*;

--- a/packages/core/src/components/mod.rs
+++ b/packages/core/src/components/mod.rs
@@ -1,5 +1,7 @@
 mod layer;
+mod level;
 mod project;
 
 pub use layer::*;
+pub use level::*;
 pub use project::*;

--- a/packages/core/src/components/texture.rs
+++ b/packages/core/src/components/texture.rs
@@ -1,6 +1,9 @@
 use bevy::prelude::{Component, Rectangle};
 use serde::{Deserialize, Serialize};
 
+/// Marker component for a texture ("plain" image).
+///
+/// We store the size [Rectangle] since we can't reconstruct it from a mesh later.
 #[derive(Component, Serialize, Deserialize)]
 pub struct Texture {
     pub size: Rectangle,

--- a/packages/core/src/components/texture.rs
+++ b/packages/core/src/components/texture.rs
@@ -1,0 +1,7 @@
+use bevy::prelude::{Component, Rectangle};
+use serde::{Deserialize, Serialize};
+
+#[derive(Component, Serialize, Deserialize)]
+pub struct Texture {
+    pub size: Rectangle,
+}

--- a/packages/core/src/constants.rs
+++ b/packages/core/src/constants.rs
@@ -1,6 +1,6 @@
-// /// The version of DungeonRS.
-// /// This is used for releases as well as determining the save file versioning.
-// pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// The version of DungeonRS.
+/// This is used for releases as well as determining the save file versioning.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The number of world units per cell.
 /// This determines how "wide" cells in the map grid are.

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -10,7 +10,8 @@ use bevy::prelude::Plugin;
 
 pub mod prelude {
     pub use crate::{
-        components::*, export::events::*, persistence::events::save_project_request::*,
+        components::*, export::events::*, persistence::events::load_project_request::*,
+        persistence::events::save_project_request::*,
     };
 }
 

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -2,6 +2,7 @@ mod components;
 mod constants;
 mod export;
 mod persistence;
+mod utils;
 
 use crate::export::ExportPlugin;
 use crate::persistence::PersistencePlugin;

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -1,13 +1,15 @@
 mod components;
 mod constants;
 mod export;
+mod persistence;
 
 use crate::export::ExportPlugin;
+use crate::persistence::PersistencePlugin;
 use bevy::app::App;
 use bevy::prelude::Plugin;
 
 pub mod prelude {
-    pub use crate::{components::*, export::events::*};
+    pub use crate::{components::*, export::events::*, persistence::events::save_project_request::*};
 }
 
 #[derive(Default)]
@@ -15,6 +17,6 @@ pub struct CorePlugin;
 
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((ExportPlugin,));
+        app.add_plugins((ExportPlugin, PersistencePlugin));
     }
 }

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -9,7 +9,9 @@ use bevy::app::App;
 use bevy::prelude::Plugin;
 
 pub mod prelude {
-    pub use crate::{components::*, export::events::*, persistence::events::save_project_request::*};
+    pub use crate::{
+        components::*, export::events::*, persistence::events::save_project_request::*,
+    };
 }
 
 #[derive(Default)]

--- a/packages/core/src/persistence/entities/image.rs
+++ b/packages/core/src/persistence/entities/image.rs
@@ -1,13 +1,20 @@
-use bevy::prelude::{Rectangle, Transform};
+use bevy::prelude::{Color, Rectangle, Transform};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Represents a "plain" image.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Image {
+    /// An optional name that can be used to identify this image.
     pub name: Option<String>,
+    /// The path to the texture that this [Image] should render.
+    /// Should be a path that the AssetServer can find.
     pub path: PathBuf,
-    pub alpha: f32,
+    /// The [Color] to render this image at, set to [Color::WHITE] for it not to be modified.
+    /// You can control the transparency of the image through the alpha of this colour.
+    pub colour: Color,
+    /// The [Rectangle] representing the size of the mesh this texture renders on.
     pub size: Rectangle,
+    /// The [Transform] determines the location, scale and rotation of the texture.
     pub transform: Transform,
 }

--- a/packages/core/src/persistence/entities/image.rs
+++ b/packages/core/src/persistence/entities/image.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::Transform;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Image {
+    pub path: PathBuf,
+    pub alpha: f32,
+    pub transform: Transform,
+}

--- a/packages/core/src/persistence/entities/image.rs
+++ b/packages/core/src/persistence/entities/image.rs
@@ -2,9 +2,10 @@ use bevy::prelude::{Rectangle, Transform};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Represents a "plain" image.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Image {
-    pub name: String,
+    pub name: Option<String>,
     pub path: PathBuf,
     pub alpha: f32,
     pub size: Rectangle,

--- a/packages/core/src/persistence/entities/image.rs
+++ b/packages/core/src/persistence/entities/image.rs
@@ -1,10 +1,12 @@
-use bevy::prelude::Transform;
+use bevy::prelude::{Rectangle, Transform};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Image {
+    pub name: String,
     pub path: PathBuf,
     pub alpha: f32,
+    pub size: Rectangle,
     pub transform: Transform,
 }

--- a/packages/core/src/persistence/entities/layer.rs
+++ b/packages/core/src/persistence/entities/layer.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 pub struct Layer {
     /// The name that identifies this [Layer] in the UI.
     pub name: String,
-    /// [crate::components::Layer] weight.
+    /// The weight determines the order in which layers are rendered.
+    /// A higher weight will render on top, making this an abstraction of the Z index.
     pub weight: i32,
     /// A list of all [Image]s in this layer.
     pub images: Vec<Image>,

--- a/packages/core/src/persistence/entities/layer.rs
+++ b/packages/core/src/persistence/entities/layer.rs
@@ -1,14 +1,19 @@
 use crate::persistence::entities::image::Image;
 use serde::{Deserialize, Serialize};
 
+/// Counterpart of [crate::components::Layer].
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Layer {
+    /// The name that identifies this [Layer] in the UI.
     pub name: String,
+    /// [crate::components::Layer] weight.
     pub weight: i32,
+    /// A list of all [Image]s in this layer.
     pub images: Vec<Image>,
 }
 
 impl Layer {
+    /// Generates a new [Layer] with a given name and [Image]s.
     pub fn new(name: impl Into<String>, weight: i32, images: Vec<Image>) -> Self {
         Self {
             name: name.into(),

--- a/packages/core/src/persistence/entities/layer.rs
+++ b/packages/core/src/persistence/entities/layer.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Layer {
+    pub name: String,
+    pub weight: i32,
+}
+
+impl Layer {
+    pub fn new(name: impl Into<String>, weight: i32) -> Self {
+        Self {
+            name: name.into(),
+            weight,
+        }
+    }
+}

--- a/packages/core/src/persistence/entities/layer.rs
+++ b/packages/core/src/persistence/entities/layer.rs
@@ -1,16 +1,19 @@
+use crate::persistence::entities::image::Image;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Layer {
     pub name: String,
     pub weight: i32,
+    pub images: Vec<Image>,
 }
 
 impl Layer {
-    pub fn new(name: impl Into<String>, weight: i32) -> Self {
+    pub fn new(name: impl Into<String>, weight: i32, images: Vec<Image>) -> Self {
         Self {
             name: name.into(),
             weight,
+            images,
         }
     }
 }

--- a/packages/core/src/persistence/entities/level.rs
+++ b/packages/core/src/persistence/entities/level.rs
@@ -1,0 +1,17 @@
+use crate::persistence::entities::layer::Layer;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Level {
+    pub name: String,
+    pub layers: Vec<Layer>,
+}
+
+impl Level {
+    pub fn new(name: impl Into<String>, layers: Vec<Layer>) -> Self {
+        Self {
+            name: name.into(),
+            layers,
+        }
+    }
+}

--- a/packages/core/src/persistence/entities/level.rs
+++ b/packages/core/src/persistence/entities/level.rs
@@ -1,13 +1,17 @@
 use crate::persistence::entities::layer::Layer;
 use serde::{Deserialize, Serialize};
 
+/// Counterpart of [crate::components::Level].
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Level {
+    /// The name that identifies this [Level] in the UI.
     pub name: String,
+    /// All [Layer]s under this [Level].
     pub layers: Vec<Layer>,
 }
 
 impl Level {
+    /// Generates a new [Level] with a given name and [Layer]s.
     pub fn new(name: impl Into<String>, layers: Vec<Layer>) -> Self {
         Self {
             name: name.into(),

--- a/packages/core/src/persistence/entities/mod.rs
+++ b/packages/core/src/persistence/entities/mod.rs
@@ -2,5 +2,6 @@
 //!
 //! If information and/or data should be persisted for a project or its dependencies, it should go here.
 
+pub(super) mod image;
 pub(super) mod layer;
 pub(super) mod level;

--- a/packages/core/src/persistence/entities/mod.rs
+++ b/packages/core/src/persistence/entities/mod.rs
@@ -1,0 +1,6 @@
+//! Structs here are not intended to be constructed for ECS, they serve solely for serialisation.
+//!
+//! If information and/or data should be persisted for a project or its dependencies, it should go here.
+
+pub(super) mod layer;
+pub(super) mod level;

--- a/packages/core/src/persistence/events/load_project_request.rs
+++ b/packages/core/src/persistence/events/load_project_request.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use bevy::prelude::Event;
+use std::path::PathBuf;
 
 #[derive(Event)]
 pub struct LoadProjectRequest {

--- a/packages/core/src/persistence/events/load_project_request.rs
+++ b/packages/core/src/persistence/events/load_project_request.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+use bevy::prelude::Event;
+
+#[derive(Event)]
+pub struct LoadProjectRequest {
+    pub path: PathBuf,
+}
+
+impl LoadProjectRequest {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}

--- a/packages/core/src/persistence/events/load_project_request.rs
+++ b/packages/core/src/persistence/events/load_project_request.rs
@@ -1,12 +1,15 @@
 use bevy::prelude::Event;
 use std::path::PathBuf;
 
+/// Event fired when the user requests to load a project.
 #[derive(Event)]
 pub struct LoadProjectRequest {
+    /// The path to the savefile to load.
     pub path: PathBuf,
 }
 
 impl LoadProjectRequest {
+    /// Creates a new [LoadProjectRequest] event.
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self { path: path.into() }
     }

--- a/packages/core/src/persistence/events/mod.rs
+++ b/packages/core/src/persistence/events/mod.rs
@@ -1,0 +1,1 @@
+pub mod save_project_request;

--- a/packages/core/src/persistence/events/mod.rs
+++ b/packages/core/src/persistence/events/mod.rs
@@ -1,1 +1,2 @@
 pub mod save_project_request;
+pub mod load_project_request;

--- a/packages/core/src/persistence/events/mod.rs
+++ b/packages/core/src/persistence/events/mod.rs
@@ -1,2 +1,2 @@
-pub mod save_project_request;
 pub mod load_project_request;
+pub mod save_project_request;

--- a/packages/core/src/persistence/events/save_project_request.rs
+++ b/packages/core/src/persistence/events/save_project_request.rs
@@ -1,12 +1,15 @@
 use bevy::prelude::Event;
 use std::path::PathBuf;
 
+/// Event fired when the user requests to save the project.
 #[derive(Event)]
 pub struct SaveProjectRequest {
+    /// The path to save the project to.
     pub path: PathBuf,
 }
 
 impl SaveProjectRequest {
+    /// Creates a new [SaveProjectRequest] event.
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Self { path: path.into() }
     }

--- a/packages/core/src/persistence/events/save_project_request.rs
+++ b/packages/core/src/persistence/events/save_project_request.rs
@@ -1,0 +1,13 @@
+use bevy::prelude::Event;
+use std::path::PathBuf;
+
+#[derive(Event)]
+pub struct SaveProjectRequest {
+    pub path: PathBuf,
+}
+
+impl SaveProjectRequest {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}

--- a/packages/core/src/persistence/mod.rs
+++ b/packages/core/src/persistence/mod.rs
@@ -46,7 +46,7 @@ fn poll_save_project_events(
     children_query: Query<&Children>,
     level_query: Query<&Name, With<Level>>,
     layer_query: Query<(&Layer, &Name)>,
-    mesh_query: Query<(&Texture, &Name), With<Mesh2d>>,
+    mesh_query: Query<(&Texture, Option<&Name>), With<Mesh2d>>,
     transform_query: Query<&Transform>,
     material_query: Query<&MeshMaterial2d<ColorMaterial>>,
     materials: Res<Assets<ColorMaterial>>,

--- a/packages/core/src/persistence/mod.rs
+++ b/packages/core/src/persistence/mod.rs
@@ -21,8 +21,8 @@ use crate::utils;
 use bevy::app::App;
 use bevy::asset::{AssetServer, Assets};
 use bevy::prelude::{
-    info, Children, ColorMaterial, Commands, Entity, EventReader, FixedPostUpdate, Mesh,
-    Mesh2d, MeshMaterial2d, Name, Plugin, Query, Res, ResMut, Result, Transform, With,
+    Children, ColorMaterial, Commands, Entity, EventReader, FixedPostUpdate, Mesh, Mesh2d,
+    MeshMaterial2d, Name, Plugin, Query, Res, ResMut, Result, Transform, With, info,
 };
 use std::fs::write;
 

--- a/packages/core/src/persistence/mod.rs
+++ b/packages/core/src/persistence/mod.rs
@@ -46,7 +46,7 @@ fn poll_save_project_events(
     project_query: Query<(&Project, &Name, &Children), With<Project>>,
     children_query: Query<&Children>,
     level_query: Query<&Name, With<Level>>,
-    layer_query: Query<(&Layer, &Name)>,
+    layer_query: Query<(&Transform, &Name), With<Layer>>,
     mesh_query: Query<(&Texture, Option<&Name>), With<Mesh2d>>,
     transform_query: Query<&Transform>,
     material_query: Query<&MeshMaterial2d<ColorMaterial>>,

--- a/packages/core/src/persistence/mod.rs
+++ b/packages/core/src/persistence/mod.rs
@@ -44,9 +44,8 @@ impl Plugin for PersistencePlugin {
 fn poll_save_project_events(
     mut save_projects: EventReader<SaveProjectRequest>,
     project_query: Query<(&Project, &Name, &Children), With<Project>>,
-    children_query: Query<&Children>,
-    level_query: Query<&Name, With<Level>>,
-    layer_query: Query<(&Transform, &Name), With<Layer>>,
+    level_query: Query<(&Name, &Children), With<Level>>,
+    layer_query: Query<(&Transform, &Name, &Children), With<Layer>>,
     mesh_query: Query<(&Texture, Option<&Name>), With<Mesh2d>>,
     transform_query: Query<&Transform>,
     material_query: Query<&MeshMaterial2d<ColorMaterial>>,
@@ -55,7 +54,6 @@ fn poll_save_project_events(
     for save_project in save_projects.read() {
         let save = SaveFile::new(
             project_query,
-            children_query,
             level_query,
             layer_query,
             mesh_query,

--- a/packages/core/src/persistence/mod.rs
+++ b/packages/core/src/persistence/mod.rs
@@ -1,0 +1,42 @@
+//! The persistence module handles saving and restoring DungeonRS' state from (and to) disk.
+//!
+//! This module contains copies of a lot of data structures found in Core, but this is intentional,
+//! the copies contained in this module are intended (and optimised) for serialisation.
+//! These copies can be found under [crate::persistence::entities].
+//!
+//! Serialisation logic itself is implemented using [Serde](https://serde.rs/), keeping the format
+//! to which we serialise flexible.
+//! Currently, large datasets (like projects) will be serialised using [MessagePack](https://msgpack.org/)
+//! while smaller files intended to be edited by users (like config) will be serialised using JSON or [Ron](https://docs.rs/ron).
+
+pub(super) mod entities;
+pub(super) mod events;
+pub(super) mod save_file;
+
+use crate::persistence::save_file::SaveFile;
+use crate::prelude::SaveProjectRequest;
+use bevy::app::App;
+use bevy::asset::ron::ser::to_string_pretty;
+use bevy::prelude::{default, EventReader, FixedPostUpdate, Plugin};
+use std::fs::write;
+
+#[derive(Default)]
+pub struct PersistencePlugin;
+
+impl Plugin for PersistencePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<SaveProjectRequest>();
+        app.add_systems(FixedPostUpdate, poll_save_project_events);
+    }
+}
+
+fn poll_save_project_events(mut save_projects: EventReader<SaveProjectRequest>) {
+    for save_project in save_projects.read() {
+        let save = SaveFile::new();
+        write(
+            "output.drs",
+            to_string_pretty(&save, default()).expect("FAILED TO SERIALISE"),
+        )
+            .expect("FAILED TO SAVE");
+    }
+}

--- a/packages/core/src/persistence/save_file.rs
+++ b/packages/core/src/persistence/save_file.rs
@@ -4,22 +4,37 @@ use crate::persistence::entities::{image::Image, layer::Layer, level::Level};
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
+/// Represents the information that is written/read from/to disk.
+///
+/// Anything about a project that needs to be persisted should be included in this data structure.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SaveFile {
+    /// The version of the software that created the save.
     pub version: String,
+    /// The (semantic) name of the map (unrelated to the filename).
     pub name: String,
+    /// The canvas size, while currently not enforced, determines the export region.
     pub size: Rect,
+    /// A list of all levels that are currently included in the project.
     pub levels: Vec<Level>,
 }
 
 impl SaveFile {
+    /// Builds a [SaveFile] based on the current ECS hierarchy.
+    ///
+    /// This method queries and captures the following ECS structure:
+    ///
+    /// [Project] <br />
+    /// | -> [crate::components::Level] <br />
+    /// | ----> [crate::components::Layer] <br />
+    /// | --------> images, paths, patterns, ...
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         project_query: Query<(&Project, &Name, &Children), With<Project>>,
         children_query: Query<&Children>,
         level_query: Query<&Name, With<LevelComponent>>,
         layer_query: Query<(&LayerComponent, &Name)>,
-        mesh_query: Query<(&Texture, &Name), With<Mesh2d>>,
+        mesh_query: Query<(&Texture, Option<&Name>), With<Mesh2d>>,
         transform_query: Query<&Transform>,
         material_query: Query<&MeshMaterial2d<ColorMaterial>>,
         materials: &Res<Assets<ColorMaterial>>,
@@ -46,7 +61,7 @@ impl SaveFile {
                         if let Some(texture_handle) = &material.texture {
                             if let Some(path) = texture_handle.path() {
                                 images.push(Image {
-                                    name: name.to_string(),
+                                    name: name.and_then(|name| Some(name.to_string())),
                                     path: path.path().to_path_buf(),
                                     alpha: material.color.alpha(),
                                     size: texture.size,
@@ -75,6 +90,8 @@ impl SaveFile {
         })
     }
 
+    /// Rebuilds the ECS structure represented in this [SaveFile] back into [Commands].
+    /// It automatically constructs and registers all required meshes, materials and assets.
     pub fn restore(
         &self,
         commands: &mut Commands,
@@ -102,8 +119,11 @@ impl SaveFile {
 
                         child.with_children(|grand_child| {
                             for image in &layer.images {
+                                if let Some(name) = &image.name {
+                                    grand_child.spawn(Name::new(name.clone()));
+                                }
+
                                 grand_child.spawn((
-                                    Name::new(image.name.clone()),
                                     Mesh2d(meshes.add(image.size)),
                                     MeshMaterial2d(materials.add(ColorMaterial {
                                         texture: Some(asset_server.load(image.path.clone())),

--- a/packages/core/src/persistence/save_file.rs
+++ b/packages/core/src/persistence/save_file.rs
@@ -1,0 +1,27 @@
+use crate::persistence::entities::layer::Layer;
+use crate::persistence::entities::level::Level;
+use bevy::prelude::Rect;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SaveFile {
+    pub version: &'static str,
+    pub size: Rect,
+    pub levels: Vec<Level>,
+}
+
+impl SaveFile {
+    pub fn new() -> Self {
+        Self {
+            version: "0.0.1",
+            size: Rect::new(0.0, 0.0, 100.0, 100.0),
+            levels: vec![
+                Level::new(
+                    "default",
+                    vec![Layer::new("default", 0), Layer::new("background", 0)],
+                ),
+                Level::new("basement", vec![]),
+            ],
+        }
+    }
+}

--- a/packages/core/src/persistence/save_file.rs
+++ b/packages/core/src/persistence/save_file.rs
@@ -1,6 +1,6 @@
-use crate::persistence::entities::layer::Layer;
-use crate::persistence::entities::level::Level;
-use bevy::prelude::Rect;
+use crate::components::{Layer as LayerComponent, Level as LevelComponent, Project};
+use crate::persistence::entities::{image::Image, layer::Layer, level::Level};
+use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -11,17 +11,62 @@ pub struct SaveFile {
 }
 
 impl SaveFile {
-    pub fn new() -> Self {
-        Self {
-            version: "0.0.1",
-            size: Rect::new(0.0, 0.0, 100.0, 100.0),
-            levels: vec![
-                Level::new(
-                    "default",
-                    vec![Layer::new("default", 0), Layer::new("background", 0)],
-                ),
-                Level::new("basement", vec![]),
-            ],
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        project_query: Query<&Children, With<Project>>,
+        children_query: Query<&Children>,
+        level_query: Query<&Name, With<LevelComponent>>,
+        layer_query: Query<(&LayerComponent, &Name)>,
+        mesh_query: Query<&Mesh2d>,
+        transform_query: Query<&Transform>,
+        material_query: Query<&MeshMaterial2d<ColorMaterial>>,
+        materials: &Res<Assets<ColorMaterial>>,
+    ) -> Result<Self, BevyError> {
+        let project_children = project_query.single()?;
+        let mut levels = Vec::new();
+
+        for level_entity in project_children.iter() {
+            let level_name = level_query.get(level_entity)?;
+            let mut layers = Vec::new();
+
+            let level_children = children_query.get(level_entity)?;
+            for layer_entity in level_children.iter() {
+                let (layer_component, layer_name) = layer_query.get(layer_entity)?;
+
+                let mut images = Vec::new();
+                let layer_children = children_query.get(layer_entity)?;
+                for entity in layer_children.iter() {
+                    let _mesh = mesh_query.get(entity)?;
+                    let transform = transform_query.get(entity)?;
+                    let material_handle = material_query.get(entity)?;
+
+                    if let Some(material) = materials.get(material_handle) {
+                        if let Some(texture_handle) = &material.texture {
+                            if let Some(path) = texture_handle.path() {
+                                images.push(Image {
+                                    path: path.path().to_path_buf(),
+                                    alpha: material.color.alpha(),
+                                    transform: *transform,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                layers.push(Layer::new(
+                    layer_name.as_str(),
+                    layer_component.weight,
+                    images,
+                ));
+            }
+
+            levels.push(Level::new(level_name.as_str(), layers));
         }
+
+        Ok(Self {
+            version: "0.0.1",
+            size: Rect::from_center_size(Vec2::ZERO, Vec2::splat(100.0)),
+            levels,
+        })
     }
 }

--- a/packages/core/src/persistence/save_file.rs
+++ b/packages/core/src/persistence/save_file.rs
@@ -61,9 +61,9 @@ impl SaveFile {
                         if let Some(texture_handle) = &material.texture {
                             if let Some(path) = texture_handle.path() {
                                 images.push(Image {
-                                    name: name.and_then(|name| Some(name.to_string())),
+                                    name: name.map(|name| name.to_string()),
                                     path: path.path().to_path_buf(),
-                                    alpha: material.color.alpha(),
+                                    colour: material.color,
                                     size: texture.size,
                                     transform: *transform,
                                 });
@@ -126,6 +126,7 @@ impl SaveFile {
                                 grand_child.spawn((
                                     Mesh2d(meshes.add(image.size)),
                                     MeshMaterial2d(materials.add(ColorMaterial {
+                                        color: image.colour,
                                         texture: Some(asset_server.load(image.path.clone())),
                                         ..default()
                                     })),

--- a/packages/core/src/persistence/save_file.rs
+++ b/packages/core/src/persistence/save_file.rs
@@ -31,9 +31,8 @@ impl SaveFile {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         project_query: Query<(&Project, &Name, &Children), With<Project>>,
-        children_query: Query<&Children>,
-        level_query: Query<&Name, With<LevelComponent>>,
-        layer_query: Query<(&Transform, &Name), With<LayerComponent>>,
+        level_query: Query<(&Name, &Children), With<LevelComponent>>,
+        layer_query: Query<(&Transform, &Name, &Children), With<LayerComponent>>,
         mesh_query: Query<(&Texture, Option<&Name>), With<Mesh2d>>,
         transform_query: Query<&Transform>,
         material_query: Query<&MeshMaterial2d<ColorMaterial>>,
@@ -43,15 +42,14 @@ impl SaveFile {
         let mut levels = Vec::new();
 
         for level_entity in project_children.iter() {
-            let level_name = level_query.get(level_entity)?;
+            let (level_name, level_children) = level_query.get(level_entity)?;
             let mut layers = Vec::new();
 
-            let level_children = children_query.get(level_entity)?;
             for layer_entity in level_children.iter() {
-                let (layer_transform, layer_name) = layer_query.get(layer_entity)?;
+                let (layer_transform, layer_name, layer_children) =
+                    layer_query.get(layer_entity)?;
 
                 let mut images = Vec::new();
-                let layer_children = children_query.get(layer_entity)?;
                 for entity in layer_children.iter() {
                     let (texture, name) = mesh_query.get(entity)?;
                     let transform = transform_query.get(entity)?;

--- a/packages/core/src/utils.rs
+++ b/packages/core/src/utils.rs
@@ -1,0 +1,54 @@
+//! Contains small utility functions for DungeonRS.
+
+use serde::Serialize;
+
+/// Serializes the given [T] using the configured serializer.
+pub fn serialize<T>(subject: &T) -> Result<Vec<u8>, String>
+where
+    T: Serialize,
+{
+    #[cfg(feature = "json")]
+    return match serde_json::to_string_pretty(subject) {
+        Ok(json) => Ok(json.into()),
+        Err(error) => Err(error.to_string()),
+    };
+
+    #[allow(unreachable_code)]
+    #[cfg(feature = "msgpack")]
+    return match rmp_serde::to_vec(subject) {
+        Ok(result) => Ok(result),
+        Err(error) => Err(error.to_string()),
+    };
+
+    #[cfg(not(any(feature = "json", feature = "msgpack")))]
+    compile_error!(
+        "Either the `json` or `msgpack` feature must be enabled for serialization to work."
+    );
+}
+
+/// Deserializes the given bytes into the specified type using the configured deserializer.
+pub fn deserialize<T>(bytes: &[u8]) -> Result<T, String>
+where
+    T: serde::de::DeserializeOwned,
+{
+    #[cfg(feature = "json")]
+    return match std::str::from_utf8(bytes) {
+        Ok(s) => match serde_json::from_str(s) {
+            Ok(result) => Ok(result),
+            Err(error) => Err(error.to_string()),
+        },
+        Err(err) => Err(err.to_string()),
+    };
+
+    #[allow(unreachable_code)]
+    #[cfg(feature = "msgpack")]
+    return match rmp_serde::from_slice(bytes) {
+        Ok(msgpack) => Ok(msgpack),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    #[cfg(not(any(feature = "json", feature = "msgpack")))]
+    compile_error!(
+        "Either the `json` or `msgpack` feature must be enabled for deserialization to work."
+    );
+}

--- a/packages/editor/Cargo.toml
+++ b/packages/editor/Cargo.toml
@@ -27,7 +27,7 @@ image = { version = "0.25.6", default-features = false, features = ["png", "ico"
 winresource = "0.1.20"
 
 [features]
-default = ["dev"]
+default = ["dev", "core/json"]
 dev = [
   "bevy/trace",
   "bevy/track_location",

--- a/packages/editor/src/main.rs
+++ b/packages/editor/src/main.rs
@@ -13,7 +13,12 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
     commands.spawn(Camera2d);
 
     commands.spawn((
@@ -28,12 +33,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 children![
                     (
                         Name::new("Logo"),
-                        Sprite::from_image(asset_server.load("logo.png")),
+                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                        generate_image(&mut materials, &asset_server),
                         Transform::from_xyz(0., 0., 0.),
                     ),
                     (
                         Name::new("Logo 2"),
-                        Sprite::from_image(asset_server.load("logo.png")),
+                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                        generate_image(&mut materials, &asset_server),
                         Transform::from_xyz(250., 0., 0.),
                     ),
                 ]
@@ -44,12 +51,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 children![
                     (
                         Name::new("Logo 3"),
-                        Sprite::from_image(asset_server.load("logo.png")),
+                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                        generate_image(&mut materials, &asset_server),
                         Transform::from_xyz(0., 250., 0.),
                     ),
                     (
                         Name::new("Logo 4"),
-                        Sprite::from_image(asset_server.load("logo.png")),
+                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                        generate_image(&mut materials, &asset_server),
                         Transform::from_xyz(250., 250., 0.),
                     ),
                 ]
@@ -63,6 +72,12 @@ fn update(
     mut completed: EventReader<ExportCompleted>,
     mut gizmos: Gizmos,
 ) {
+    gizmos.rect_2d(
+        Vec2::ZERO,
+        Vec2::splat(256.),
+        Color::srgb(1.0, 0., 0.)
+    );
+
     gizmos
         .grid_2d(
             Isometry2d::IDENTITY,
@@ -79,4 +94,14 @@ fn update(
     for completed in completed.read() {
         info!("Export completed: {:#?}", completed);
     }
+}
+
+fn generate_image(
+    materials: &mut ResMut<Assets<ColorMaterial>>,
+    asset_server: &Res<AssetServer>,
+) -> MeshMaterial2d<ColorMaterial> {
+    MeshMaterial2d(materials.add(ColorMaterial {
+        texture: Some(asset_server.load("logo.png")),
+        ..default()
+    }))
 }

--- a/packages/editor/src/main.rs
+++ b/packages/editor/src/main.rs
@@ -33,7 +33,7 @@ fn setup(
             children![
                 (
                     Name::new("Default Layer"),
-                    Layer::default(),
+                    Layer,
                     children![
                         (
                             Name::new("Logo"),

--- a/packages/editor/src/main.rs
+++ b/packages/editor/src/main.rs
@@ -13,63 +13,8 @@ fn main() {
         .run();
 }
 
-fn setup(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
-    mut meshes: ResMut<Assets<Mesh>>,
-) {
+fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
-
-    commands.spawn((
-        Name::new("Project"),
-        Project::new(
-            "example",
-            Rect::from_center_size(Vec2::ZERO, Vec2::splat(1000.)),
-        ),
-        children![(
-            Name::new("Root"),
-            Level,
-            children![
-                (
-                    Name::new("Default Layer"),
-                    Layer::default(),
-                    children![
-                        (
-                            Name::new("Logo"),
-                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
-                            generate_image(&mut materials, &asset_server),
-                            Transform::from_xyz(0., 0., 0.),
-                        ),
-                        (
-                            Name::new("Logo 2"),
-                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
-                            generate_image(&mut materials, &asset_server),
-                            Transform::from_xyz(250., 0., 0.),
-                        ),
-                    ]
-                ),
-                (
-                    Name::new("Background Layer"),
-                    Layer { weight: -1 },
-                    children![
-                        (
-                            Name::new("Logo 3"),
-                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
-                            generate_image(&mut materials, &asset_server),
-                            Transform::from_xyz(0., 250., 0.),
-                        ),
-                        (
-                            Name::new("Logo 4"),
-                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
-                            generate_image(&mut materials, &asset_server),
-                            Transform::from_xyz(250., 250., 0.),
-                        ),
-                    ]
-                ),
-            ]
-        )],
-    ));
 }
 
 fn update(
@@ -95,14 +40,4 @@ fn update(
     for completed in completed.read() {
         info!("Export completed: {:#?}", completed);
     }
-}
-
-fn generate_image(
-    materials: &mut ResMut<Assets<ColorMaterial>>,
-    asset_server: &Res<AssetServer>,
-) -> MeshMaterial2d<ColorMaterial> {
-    MeshMaterial2d(materials.add(ColorMaterial {
-        texture: Some(asset_server.load("logo.png")),
-        ..default()
-    }))
 }

--- a/packages/editor/src/main.rs
+++ b/packages/editor/src/main.rs
@@ -57,7 +57,8 @@ fn setup(
                 ),
                 (
                     Name::new("Background Layer"),
-                    Layer { weight: -1 },
+                    Layer,
+                    Transform::from_xyz(0., 0., -1.),
                     children![
                         (
                             Name::new("Logo 3"),

--- a/packages/editor/src/main.rs
+++ b/packages/editor/src/main.rs
@@ -13,8 +13,74 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands) {
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
     commands.spawn(Camera2d);
+
+    commands.spawn((
+        Name::new("Project"),
+        Project::new(
+            "example",
+            Rect::from_center_size(Vec2::ZERO, Vec2::splat(1000.)),
+        ),
+        children![(
+            Name::new("Root"),
+            Level,
+            children![
+                (
+                    Name::new("Default Layer"),
+                    Layer::default(),
+                    children![
+                        (
+                            Name::new("Logo"),
+                            Texture {
+                                size: Rectangle::from_size(Vec2::splat(256.))
+                            },
+                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                            generate_image(&mut materials, &asset_server),
+                            Transform::from_xyz(0., 0., 0.),
+                        ),
+                        (
+                            Name::new("Logo 2"),
+                            Texture {
+                                size: Rectangle::from_size(Vec2::splat(256.))
+                            },
+                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                            generate_image(&mut materials, &asset_server),
+                            Transform::from_xyz(250., 0., 0.),
+                        ),
+                    ]
+                ),
+                (
+                    Name::new("Background Layer"),
+                    Layer { weight: -1 },
+                    children![
+                        (
+                            Name::new("Logo 3"),
+                            Texture {
+                                size: Rectangle::from_size(Vec2::splat(256.))
+                            },
+                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                            generate_image(&mut materials, &asset_server),
+                            Transform::from_xyz(0., 250., 0.),
+                        ),
+                        (
+                            Texture {
+                                size: Rectangle::from_size(Vec2::splat(256.))
+                            },
+                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                            generate_image(&mut materials, &asset_server),
+                            Transform::from_xyz(250., 250., 0.),
+                        ),
+                    ]
+                ),
+            ]
+        )],
+    ));
 }
 
 fn update(
@@ -40,4 +106,14 @@ fn update(
     for completed in completed.read() {
         info!("Export completed: {:#?}", completed);
     }
+}
+
+fn generate_image(
+    materials: &mut ResMut<Assets<ColorMaterial>>,
+    asset_server: &Res<AssetServer>,
+) -> MeshMaterial2d<ColorMaterial> {
+    MeshMaterial2d(materials.add(ColorMaterial {
+        texture: Some(asset_server.load("logo.png")),
+        ..default()
+    }))
 }

--- a/packages/editor/src/main.rs
+++ b/packages/editor/src/main.rs
@@ -22,48 +22,53 @@ fn setup(
     commands.spawn(Camera2d);
 
     commands.spawn((
+        Name::new("Project"),
         Project::new(
             "example",
             Rect::from_center_size(Vec2::ZERO, Vec2::splat(1000.)),
         ),
-        children![
-            (
-                Name::new("Default Layer"),
-                Layer::default(),
-                children![
-                    (
-                        Name::new("Logo"),
-                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
-                        generate_image(&mut materials, &asset_server),
-                        Transform::from_xyz(0., 0., 0.),
-                    ),
-                    (
-                        Name::new("Logo 2"),
-                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
-                        generate_image(&mut materials, &asset_server),
-                        Transform::from_xyz(250., 0., 0.),
-                    ),
-                ]
-            ),
-            (
-                Name::new("Background Layer"),
-                Layer { weight: -1 },
-                children![
-                    (
-                        Name::new("Logo 3"),
-                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
-                        generate_image(&mut materials, &asset_server),
-                        Transform::from_xyz(0., 250., 0.),
-                    ),
-                    (
-                        Name::new("Logo 4"),
-                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
-                        generate_image(&mut materials, &asset_server),
-                        Transform::from_xyz(250., 250., 0.),
-                    ),
-                ]
-            ),
-        ],
+        children![(
+            Name::new("Root"),
+            Level,
+            children![
+                (
+                    Name::new("Default Layer"),
+                    Layer::default(),
+                    children![
+                        (
+                            Name::new("Logo"),
+                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                            generate_image(&mut materials, &asset_server),
+                            Transform::from_xyz(0., 0., 0.),
+                        ),
+                        (
+                            Name::new("Logo 2"),
+                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                            generate_image(&mut materials, &asset_server),
+                            Transform::from_xyz(250., 0., 0.),
+                        ),
+                    ]
+                ),
+                (
+                    Name::new("Background Layer"),
+                    Layer { weight: -1 },
+                    children![
+                        (
+                            Name::new("Logo 3"),
+                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                            generate_image(&mut materials, &asset_server),
+                            Transform::from_xyz(0., 250., 0.),
+                        ),
+                        (
+                            Name::new("Logo 4"),
+                            Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
+                            generate_image(&mut materials, &asset_server),
+                            Transform::from_xyz(250., 250., 0.),
+                        ),
+                    ]
+                ),
+            ]
+        )],
     ));
 }
 
@@ -72,11 +77,7 @@ fn update(
     mut completed: EventReader<ExportCompleted>,
     mut gizmos: Gizmos,
 ) {
-    gizmos.rect_2d(
-        Vec2::ZERO,
-        Vec2::splat(256.),
-        Color::srgb(1.0, 0., 0.)
-    );
+    gizmos.rect_2d(Vec2::ZERO, Vec2::splat(256.), Color::srgb(1.0, 0., 0.));
 
     gizmos
         .grid_2d(

--- a/packages/headless/Cargo.toml
+++ b/packages/headless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headless"
-edition = "2024"
+edition.workspace = true
 repository.workspace = true
 version.workspace = true
 readme.workspace = true

--- a/packages/headless/Cargo.toml
+++ b/packages/headless/Cargo.toml
@@ -17,7 +17,7 @@ bevy = { workspace = true, features = [
 ] }
 
 [features]
-default = ["dev"]
+default = ["dev", "core/json"]
 dev = [
   "core/dev",
   "bevy/trace",

--- a/packages/ui/src/editor_layout.rs
+++ b/packages/ui/src/editor_layout.rs
@@ -20,7 +20,13 @@ pub fn editor_layout(
         return;
     };
 
-    toolbar(context, ui_state.logo, export_writer, save_writer, load_writer);
+    toolbar(
+        context,
+        ui_state.logo,
+        export_writer,
+        save_writer,
+        load_writer,
+    );
 
     TopBottomPanel::bottom("bottom_panel")
         .frame(egui::Frame::NONE)

--- a/packages/ui/src/editor_layout.rs
+++ b/packages/ui/src/editor_layout.rs
@@ -1,6 +1,6 @@
-use crate::widgets::toolbar::toolbar;
 use crate::UiState;
-use bevy::prelude::{warn, EventWriter, Res, With, World};
+use crate::widgets::toolbar::toolbar;
+use bevy::prelude::{EventWriter, Res, With, World, warn};
 use bevy::window::PrimaryWindow;
 use bevy_egui::{EguiContext, EguiContexts};
 use bevy_inspector_egui::bevy_inspector;

--- a/packages/ui/src/editor_layout.rs
+++ b/packages/ui/src/editor_layout.rs
@@ -13,13 +13,14 @@ pub fn editor_layout(
     ui_state: Res<UiState>,
     export_writer: EventWriter<ExportRequest>,
     save_writer: EventWriter<SaveProjectRequest>,
+    load_writer: EventWriter<LoadProjectRequest>,
 ) {
     let Some(context) = contexts.try_ctx_mut() else {
         warn!("Failed to acquire egui context");
         return;
     };
 
-    toolbar(context, ui_state.logo, export_writer, save_writer);
+    toolbar(context, ui_state.logo, export_writer, save_writer, load_writer);
 
     TopBottomPanel::bottom("bottom_panel")
         .frame(egui::Frame::NONE)

--- a/packages/ui/src/editor_layout.rs
+++ b/packages/ui/src/editor_layout.rs
@@ -1,6 +1,6 @@
-use crate::UiState;
 use crate::widgets::toolbar::toolbar;
-use bevy::prelude::{EventWriter, Res, With, World, warn};
+use crate::UiState;
+use bevy::prelude::{warn, EventWriter, Res, With, World};
 use bevy::window::PrimaryWindow;
 use bevy_egui::{EguiContext, EguiContexts};
 use bevy_inspector_egui::bevy_inspector;
@@ -12,13 +12,14 @@ pub fn editor_layout(
     mut contexts: EguiContexts,
     ui_state: Res<UiState>,
     export_writer: EventWriter<ExportRequest>,
+    save_writer: EventWriter<SaveProjectRequest>,
 ) {
     let Some(context) = contexts.try_ctx_mut() else {
         warn!("Failed to acquire egui context");
         return;
     };
 
-    toolbar(context, ui_state.logo, export_writer);
+    toolbar(context, ui_state.logo, export_writer, save_writer);
 
     TopBottomPanel::bottom("bottom_panel")
         .frame(egui::Frame::NONE)

--- a/packages/ui/src/widgets/toolbar.rs
+++ b/packages/ui/src/widgets/toolbar.rs
@@ -23,7 +23,11 @@ pub fn toolbar(
                 ui.separator();
 
                 ui.button("New").on_hover_text("Create a new map");
-                if ui.button("Open").on_hover_text("Open an existing map").clicked() {
+                if ui
+                    .button("Open")
+                    .on_hover_text("Open an existing map")
+                    .clicked()
+                {
                     load_writer.write(LoadProjectRequest {
                         path: PathBuf::from("output.drs"),
                     });

--- a/packages/ui/src/widgets/toolbar.rs
+++ b/packages/ui/src/widgets/toolbar.rs
@@ -10,6 +10,7 @@ pub fn toolbar(
     logo: SizedTexture,
     mut export_writer: EventWriter<ExportRequest>,
     mut save_writer: EventWriter<SaveProjectRequest>,
+    mut load_writer: EventWriter<LoadProjectRequest>,
 ) {
     TopBottomPanel::top("toolbar")
         .resizable(false)
@@ -22,7 +23,11 @@ pub fn toolbar(
                 ui.separator();
 
                 ui.button("New").on_hover_text("Create a new map");
-                ui.button("Open").on_hover_text("Open an existing map");
+                if ui.button("Open").on_hover_text("Open an existing map").clicked() {
+                    load_writer.write(LoadProjectRequest {
+                        path: PathBuf::from("output.drs"),
+                    });
+                }
                 if ui
                     .button("Save")
                     .on_hover_text("Save the current map")

--- a/packages/ui/src/widgets/toolbar.rs
+++ b/packages/ui/src/widgets/toolbar.rs
@@ -29,7 +29,7 @@ pub fn toolbar(
                     .clicked()
                 {
                     save_writer.write(SaveProjectRequest {
-                        path: PathBuf::from("savefile.drs"),
+                        path: PathBuf::from("output.drs"),
                     });
                 }
                 // ui.add_enabled(false, Button::new("Export"))

--- a/packages/ui/src/widgets/toolbar.rs
+++ b/packages/ui/src/widgets/toolbar.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::{EventWriter, Rect};
-use core::prelude::ExportRequest;
+use core::prelude::*;
 use egui::load::SizedTexture;
 use egui::{Context, TopBottomPanel};
 use std::path::PathBuf;
@@ -9,6 +9,7 @@ pub fn toolbar(
     context: &mut Context,
     logo: SizedTexture,
     mut export_writer: EventWriter<ExportRequest>,
+    mut save_writer: EventWriter<SaveProjectRequest>,
 ) {
     TopBottomPanel::top("toolbar")
         .resizable(false)
@@ -22,7 +23,15 @@ pub fn toolbar(
 
                 ui.button("New").on_hover_text("Create a new map");
                 ui.button("Open").on_hover_text("Open an existing map");
-                ui.button("Save").on_hover_text("Save the current map");
+                if ui
+                    .button("Save")
+                    .on_hover_text("Save the current map")
+                    .clicked()
+                {
+                    save_writer.write(SaveProjectRequest {
+                        path: PathBuf::from("savefile.drs"),
+                    });
+                }
                 // ui.add_enabled(false, Button::new("Export"))
                 //     .on_hover_text("Export the current map as an image");
 


### PR DESCRIPTION
implement serializing and deserializing the ECS hierarchy.
When working in the editor, all images, paths, textures, ... should be placed under a `Layer` which in turn should live in a `Level` which in turn lives in a `Project`.

Example:
```rust
commands.spawn((
    Name::new("Project"),
    Project::new(
        "example",
        Rect::from_center_size(Vec2::ZERO, Vec2::splat(1000.)),
    ),
    children![(
        Name::new("Root"),
        Level,
        children![
            (
                Name::new("Default Layer"),
                Layer::default(),
                children![
                    (
                        Name::new("Logo"),
                        Texture {
                            size: Rectangle::from_size(Vec2::splat(256.))
                        },
                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
                        generate_image(&mut materials, &asset_server),
                        Transform::from_xyz(0., 0., 0.),
                    ),
                    (
                        Name::new("Logo 2"),
                        Texture {
                            size: Rectangle::from_size(Vec2::splat(256.))
                        },
                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
                        generate_image(&mut materials, &asset_server),
                        Transform::from_xyz(250., 0., 0.),
                    ),
                ]
            ),
            (
                Name::new("Background Layer"),
                Layer { weight: -1 },
                children![
                    (
                        Name::new("Logo 3"),
                        Texture {
                            size: Rectangle::from_size(Vec2::splat(256.))
                        },
                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
                        generate_image(&mut materials, &asset_server),
                        Transform::from_xyz(0., 250., 0.),
                    ),
                    (
                        Texture {
                            size: Rectangle::from_size(Vec2::splat(256.))
                        },
                        Mesh2d(meshes.add(Rectangle::from_size(Vec2::splat(256.)))),
                        generate_image(&mut materials, &asset_server),
                        Transform::from_xyz(250., 250., 0.),
                    ),
                ]
            ),
        ]
    )],
));
```

currently in the `ui` package I've added example code that directs the system to save / load from disk:
```rust
if ui
    .button("Open")
    .on_hover_text("Open an existing map")
    .clicked()
{
    load_writer.write(LoadProjectRequest {
        path: PathBuf::from("output.drs"),
    });
}
if ui
    .button("Save")
    .on_hover_text("Save the current map")
    .clicked()
{
    save_writer.write(SaveProjectRequest {
        path: PathBuf::from("output.drs"),
    });
}
```

### What is out of scope
Currently saving and loading is *very* rudimentary: it panics when failure occurs, does not report any progress or success and it doesn't handle more than simple images in the hierarchy.

This is planned to be improved after the initial POC