### PR TITLE
error handling for async ECS

### DIFF
--- a/crates/io/src/save_project.rs
+++ b/crates/io/src/save_project.rs
@@ -65,21 +65,27 @@ pub fn handle_save_project(
     let entity = event.project;
     let output = event.output.clone();
     let document = Document::new(project, level_query, layer_query);
-    commands.spawn(AsyncComponent::new_io(async move |sender| {
-        let file = File::create(output.clone())
-            .with_context(|| format!("Failed to open {} for writing savefile", output.display()))?;
-        serialize_to(&document, &default(), file)?;
+    commands.spawn(AsyncComponent::new_io(
+        async move |sender| {
+            let file = File::create(output.clone()).with_context(|| {
+                format!("Failed to open {} for writing savefile", output.display())
+            })?;
+            serialize_to(&document, &default(), file)?;
 
-        // Report completion
-        report_progress(
-            &sender,
-            SaveProjectCompleteEvent {
-                project: entity,
-                output,
-            },
-        )?;
-        Ok(())
-    }));
+            // Report completion
+            report_progress(
+                &sender,
+                SaveProjectCompleteEvent {
+                    project: entity,
+                    output,
+                },
+            )?;
+            Ok(())
+        },
+        |_, _| {
+            // TODO: handle errors.
+        },
+    ));
 
     Ok(())
 }

--- a/crates/utils/tests/async_ecs.rs
+++ b/crates/utils/tests/async_ecs.rs
@@ -20,6 +20,17 @@ struct FooEvent {
     pub bar: String,
 }
 
+/// Advance the world
+fn advance_world(app: &mut App) {
+    app.update();
+    tick_global_task_pools_on_main_thread();
+    app.world_mut()
+        .resource_mut::<Time<Fixed>>()
+        .advance_by(Duration::from_secs(2));
+    app.world_mut().run_schedule(FixedPostUpdate);
+    app.update();
+}
+
 #[test]
 fn spawn_new_async() {
     let mut app = App::new();
@@ -41,13 +52,7 @@ fn spawn_new_async() {
         },
     ));
 
-    app.update(); // execute spawn of AsyncComponent
-    tick_global_task_pools_on_main_thread(); // run background runners
-    app.world_mut()
-        .resource_mut::<Time<Fixed>>()
-        .advance_by(Duration::from_secs(2)); // "advance" game time
-    app.world_mut().run_schedule(FixedPostUpdate); // force FixedPostUpdate schedule to run
-    app.update(); // run any commands that have been appended by FixedPostUpdate
+    advance_world(&mut app);
 
     let foo: Vec<&FooComponent> = app
         .world_mut()
@@ -86,13 +91,7 @@ fn calls_error_on_failure() {
         },
     ));
 
-    app.update(); // execute spawn of AsyncComponent
-    tick_global_task_pools_on_main_thread(); // run background runners
-    app.world_mut()
-        .resource_mut::<Time<Fixed>>()
-        .advance_by(Duration::from_secs(2)); // "advance" game time
-    app.world_mut().run_schedule(FixedPostUpdate); // force FixedPostUpdate schedule to run
-    app.update(); // run any commands that have been appended by FixedPostUpdate
+    advance_world(&mut app);
 
     let component = app
         .world_mut()
@@ -137,13 +136,7 @@ fn spawn_new_compute() {
         },
     ));
 
-    app.update(); // execute spawn of AsyncComponent
-    tick_global_task_pools_on_main_thread(); // Run background runners
-    app.world_mut()
-        .resource_mut::<Time<Fixed>>()
-        .advance_by(Duration::from_secs(2)); // "Advance" game time
-    app.world_mut().run_schedule(FixedPostUpdate); // Force FixedPostUpdate schedule to run
-    app.update(); // Run any commands that have been appended by FixedPostUpdate
+    advance_world(&mut app);
 
     let foo: Vec<&FooComponent> = app
         .world_mut()
@@ -184,13 +177,7 @@ fn spawn_new_io() {
         },
     ));
 
-    app.update(); // execute spawn of AsyncComponent
-    tick_global_task_pools_on_main_thread(); // Run background runners
-    app.world_mut()
-        .resource_mut::<Time<Fixed>>()
-        .advance_by(Duration::from_secs(2)); // "Advance" game time
-    app.world_mut().run_schedule(FixedPostUpdate); // Force FixedPostUpdate schedule to run
-    app.update(); // Run any commands that have been appended by FixedPostUpdate
+    advance_world(&mut app);
 
     let foo: Vec<&FooComponent> = app
         .world_mut()

--- a/crates/utils/tests/async_ecs.rs
+++ b/crates/utils/tests/async_ecs.rs
@@ -5,7 +5,7 @@
 use bevy::MinimalPlugins;
 use bevy::app::FixedPostUpdate;
 use bevy::ecs::world::CommandQueue;
-use bevy::prelude::{App, Component, Fixed, Time, World};
+use bevy::prelude::{App, BevyError, Component, Event, Events, Fixed, Time, World};
 use bevy::tasks::tick_global_task_pools_on_main_thread;
 use std::time::Duration;
 use utils::{AsyncComponent, CorePlugin};
@@ -15,13 +15,18 @@ struct FooComponent {
     pub bar: &'static str,
 }
 
+#[derive(Event)]
+struct FooEvent {
+    pub bar: String,
+}
+
 #[test]
 fn spawn_new_async() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, CorePlugin));
 
-    app.world_mut()
-        .spawn(AsyncComponent::new_async(async |sender| {
+    app.world_mut().spawn(AsyncComponent::new_async(
+        async |sender| {
             let mut queue = CommandQueue::default();
 
             queue.push(|world: &mut World| {
@@ -30,7 +35,11 @@ fn spawn_new_async() {
 
             sender.send(queue).unwrap();
             Ok(())
-        }));
+        },
+        |_, _| {
+            panic!("Should not fail");
+        },
+    ));
 
     app.update(); // execute spawn of AsyncComponent
     tick_global_task_pools_on_main_thread(); // run background runners
@@ -59,12 +68,61 @@ fn spawn_new_async() {
 }
 
 #[test]
+fn calls_error_on_failure() {
+    let mut app = App::new();
+    app.add_event::<FooEvent>();
+    app.add_plugins((MinimalPlugins, CorePlugin));
+
+    app.world_mut().spawn(AsyncComponent::new_async(
+        async |_sender| -> Result<(), BevyError> { Err(BevyError::from("this went wrong")) },
+        |error, sender| {
+            let mut queue = CommandQueue::default();
+            queue.push(move |world: &mut World| {
+                world.send_event(FooEvent {
+                    bar: error.to_string(),
+                });
+            });
+            sender.send(queue).unwrap();
+        },
+    ));
+
+    app.update(); // execute spawn of AsyncComponent
+    tick_global_task_pools_on_main_thread(); // run background runners
+    app.world_mut()
+        .resource_mut::<Time<Fixed>>()
+        .advance_by(Duration::from_secs(2)); // "advance" game time
+    app.world_mut().run_schedule(FixedPostUpdate); // force FixedPostUpdate schedule to run
+    app.update(); // run any commands that have been appended by FixedPostUpdate
+
+    let component = app
+        .world_mut()
+        .query::<&AsyncComponent>()
+        .single(app.world());
+    assert!(
+        component.is_err(),
+        "There should no longer be an AsyncComponent"
+    );
+
+    let events = app.world_mut().resource_mut::<Events<FooEvent>>();
+    let mut cursor = events.get_cursor();
+    let event = cursor.read(&events).next();
+    assert!(
+        event.is_some(),
+        "The error handler should have spawned a FooEvent"
+    );
+    assert!(
+        event.unwrap().bar.starts_with("this went wrong"),
+        "The bar should have correct value"
+    );
+}
+
+#[test]
 fn spawn_new_compute() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, CorePlugin));
 
-    app.world_mut()
-        .spawn(AsyncComponent::new_compute(async |sender| {
+    app.world_mut().spawn(AsyncComponent::new_compute(
+        async |sender| {
             let mut queue = CommandQueue::default();
 
             queue.push(|world: &mut World| {
@@ -73,7 +131,11 @@ fn spawn_new_compute() {
 
             sender.send(queue).unwrap();
             Ok(())
-        }));
+        },
+        |_, _| {
+            panic!("Should not fail");
+        },
+    ));
 
     app.update(); // execute spawn of AsyncComponent
     tick_global_task_pools_on_main_thread(); // Run background runners
@@ -106,8 +168,8 @@ fn spawn_new_io() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, CorePlugin));
 
-    app.world_mut()
-        .spawn(AsyncComponent::new_io(async |sender| {
+    app.world_mut().spawn(AsyncComponent::new_io(
+        async |sender| {
             let mut queue = CommandQueue::default();
 
             queue.push(|world: &mut World| {
@@ -116,7 +178,11 @@ fn spawn_new_io() {
 
             sender.send(queue).unwrap();
             Ok(())
-        }));
+        },
+        |_, _| {
+            panic!("Should not fail");
+        },
+    ));
 
     app.update(); // execute spawn of AsyncComponent
     tick_global_task_pools_on_main_thread(); // Run background runners


### PR DESCRIPTION
This PR adds a `handler` parameter to the `AsyncComponent` constructor that requires to pass in a second closure that takes a `BevyError` and a `Sender<CommandQueue>`.

This allows to pass in the error handling when creating a background task.
This PR also cleans up the implementation (which were 90% copy-paste anyway) to use a macro