### PR TITLE
logging feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ dependencies = [
  "data",
  "image",
  "io",
+ "logging",
  "ui",
  "utils",
  "winresource",
@@ -2788,6 +2789,16 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "logging"
+version = "0.0.1"
+dependencies = [
+ "bevy",
+ "config",
+ "tracing-appender",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "loop9"
@@ -4710,8 +4721,6 @@ dependencies = [
  "bevy",
  "config",
  "crossbeam-channel",
- "tracing-appender",
- "tracing-subscriber",
  "utils_macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "semver",
  "serde",
  "serialization",
+ "utils",
 ]
 
 [[package]]
@@ -4719,8 +4720,8 @@ name = "utils"
 version = "0.0.1"
 dependencies = [
  "bevy",
- "config",
  "crossbeam-channel",
+ "semver",
  "utils_macros",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ bevy = { version = "0.16.0", default-features = false, features = ["std", "bevy_
 anyhow = "1.0"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
+semver = { version = "1.0.26", features = ["serde"] }
 
 # Workspace packages
 config = { path = "crates/config" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ module_name_repetitions = "warn"
 semicolon_if_nothing_returned = "warn"
 
 [workspace.dependencies]
-bevy = { version = "0.16.0", default-features = false, features = ["std"] }
+bevy = { version = "0.16.0", default-features = false, features = ["std", "bevy_log"] }
 anyhow = "1.0"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -41,6 +41,7 @@ serde = { version = "1.0", features = ["derive"] }
 config = { path = "crates/config" }
 data = { path = "crates/data" }
 io = { path = "crates/io" }
+logging = { path = "crates/logging" }
 serialization = { path = "crates/serialization" }
 ui = { path = "crates/ui" }
 utils = { path = "crates/utils" }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -14,11 +14,12 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+utils = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serialization = { workspace = true }
 bevy = { workspace = true }
-semver = { version = "1.0.26", features = ["serde"] }
+semver = { workspace = true }
 
 [features]
 default = [

--- a/crates/config/src/configuration.rs
+++ b/crates/config/src/configuration.rs
@@ -3,7 +3,7 @@
 use crate::LogConfiguration;
 use anyhow::Context;
 use bevy::prelude::Resource;
-use semver::{BuildMetadata, Prerelease, Version};
+use semver::Version;
 use serialization::{Deserialize, SerializationFormat, Serialize, deserialize, serialize_to};
 use std::collections::HashMap;
 use std::env::current_exe;
@@ -37,13 +37,7 @@ const CONFIG_FILE_NAME: &str = "config.toml";
 impl Default for Configuration {
     fn default() -> Self {
         Self {
-            version: Version::parse(env!("CARGO_PKG_VERSION")).unwrap_or(Version {
-                major: 0,
-                minor: 0,
-                patch: 0,
-                pre: Prerelease::new("").unwrap(),
-                build: BuildMetadata::EMPTY,
-            }),
+            version: utils::version().clone(),
             recents: Vec::new(),
             libraries: HashMap::new(),
             logging: LogConfiguration::default(),

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -19,6 +19,7 @@ io = { workspace = true }
 ui = { workspace = true }
 utils = { workspace = true }
 config = { workspace = true }
+logging = { workspace = true }
 bevy = { workspace = true, default-features = false, features = [
   "std",
   "bevy_window",
@@ -37,28 +38,32 @@ dev = [
   "io/dev",
   "ui/dev",
   "utils/dev",
-  "config/dev"
+  "config/dev",
+  "logging/dev"
 ]
 windows = [
   "data/windows",
   "io/windows",
   "ui/windows",
   "utils/windows",
-  "config/windows"
+  "config/windows",
+  "logging/windows"
 ]
 linux = [
   "data/linux",
   "io/linux",
   "ui/linux",
   "utils/linux",
-  "config/linux"
+  "config/linux",
+  "logging/linux"
 ]
 macos = [
   "data/macos",
   "io/macos",
   "ui/macos",
   "utils/macos",
-  "config/macos"
+  "config/macos",
+  "logging/macos"
 ]
 
 # support for various image formats

--- a/crates/editor/src/main.rs
+++ b/crates/editor/src/main.rs
@@ -3,8 +3,8 @@
 use bevy::prelude::*;
 use config::Configuration;
 use io::IOPlugin;
+use logging::log_plugin;
 use ui::UIPlugin;
-use utils::log_plugin;
 
 /// Main entry point for the editor.
 ///

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -20,8 +20,15 @@ tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["json"] }
 
 [features]
-default = []
-dev = []
-windows = []
-linux = []
-macos = []
+dev = [
+  "config/dev"
+]
+windows = [
+  "config/windows"
+]
+linux = [
+  "config/linux"
+]
+macos = [
+  "config/macos"
+]

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -20,6 +20,7 @@ tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["json"] }
 
 [features]
+default = []
 dev = [
   "config/dev"
 ]

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "utils"
-description = "Crate containing helpers, macros and utilities for use in all other crates"
+name = "logging"
+description = "Handles configuration of the logging used by Bevy and the application itself"
 edition.workspace = true
 repository.workspace = true
 version.workspace = true
@@ -14,22 +14,14 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
-bevy = { workspace = true }
 config = { workspace = true }
-utils_macros = { path = "macros" }
-crossbeam-channel = "0.5.15"
+bevy = { workspace = true }
+tracing-appender = "0.2.3"
+tracing-subscriber = { version = "0.3.19", features = ["json"] }
 
 [features]
 default = []
-dev = [
-  "config/dev"
-]
-windows = [
-  "config/windows"
-]
-linux = [
-  "config/linux"
-]
-macos = [
-  "config/macos"
-]
+dev = []
+windows = []
+linux = []
+macos = []

--- a/crates/logging/README.md
+++ b/crates/logging/README.md
@@ -1,0 +1,4 @@
+# `DungeonRS logging`
+
+Handles configuring Bevy's logging system and handles outputting
+logging to a rolling file.

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,4 +1,4 @@
-//! Contains the [`log_plugin`] that returns a configured `LogPlugin`
+#![doc = include_str!("../README.md")]
 
 use bevy::log::tracing_subscriber::Layer;
 use bevy::log::tracing_subscriber::fmt::layer;

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -15,21 +15,14 @@ workspace = true
 
 [dependencies]
 bevy = { workspace = true }
-config = { workspace = true }
 utils_macros = { path = "macros" }
 crossbeam-channel = "0.5.15"
+semver = { workspace = true }
 
 [features]
 default = []
-dev = [
-  "config/dev"
-]
-windows = [
-  "config/windows"
-]
-linux = [
-  "config/linux"
-]
-macos = [
-  "config/macos"
-]
+dev = []
+windows = []
+linux = []
+macos = []
+

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,10 +1,8 @@
 #![doc = include_str!("../README.md")]
 
 mod async_ecs;
-mod logging;
 mod plugin;
 
 pub use async_ecs::*;
-pub use logging::log_plugin;
 pub use plugin::CorePlugin;
 pub use utils_macros::*;

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -2,7 +2,9 @@
 
 mod async_ecs;
 mod plugin;
+mod version;
 
 pub use async_ecs::*;
 pub use plugin::CorePlugin;
 pub use utils_macros::*;
+pub use version::version;

--- a/crates/utils/src/version.rs
+++ b/crates/utils/src/version.rs
@@ -1,0 +1,19 @@
+//! Contains the functionality to calculate the current Cargo version and make it available
+//! to the rest of the application through a `semver` `Version`.
+use semver::Version;
+use std::sync::LazyLock;
+
+/// Internal static reference to the parsed current version.
+///
+/// *Remark*: I considered making this a `const` instead of `static`, but then we'd have to either
+/// somehow do the const parsing ourselves, or hardcode it in a `Version::new` call and risk having it
+/// out of date with Cargo's version.
+static VERSION: LazyLock<Version, fn() -> Version> = LazyLock::<Version>::new(|| {
+    Version::parse(env!("CARGO_PKG_VERSION")).expect("invalid semver version")
+});
+
+/// Returns the `Version` of the software as defined in the workspace.
+#[must_use]
+pub fn version() -> &'static Version {
+    &VERSION
+}


### PR DESCRIPTION
this PR separates the logging logic into a separate package.
the reasoning is twofold:
- it moves the `config` dependency out of `utils`
    - this allows `utils` to be used in `config`
- it allows us to create a `version` method that always returns the Cargo workspace package version.

We'll need versions for save files, asset packs, … so being able to move this to a shared utils package makes it a little more future proof.