### PR TITLE
[config] update feature propagation for `utils` in `config`

### DIFF
--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -26,14 +26,18 @@ default = [
   "serialization/toml"
 ]
 dev = [
+  "utils/dev",
   "serialization/dev"
 ]
 windows = [
+  "utils/windows",
   "serialization/windows"
 ]
 linux = [
+  "utils/linux",
   "serialization/linux"
 ]
 macos = [
+  "utils/macos",
   "serialization/macos"
 ]


### PR DESCRIPTION
fixes failing CI introduced in 746dc7b